### PR TITLE
Fixed ToggleSprint behavior

### DIFF
--- a/Bloom/features/ToggleSprint.js
+++ b/Bloom/features/ToggleSprint.js
@@ -5,8 +5,8 @@ import { data } from "../utils/Utils"
 export const forwardKey = new KeyBind(Client.getMinecraft().field_71474_y.field_74351_w)
 
 register("tick", () => {
-    if (!Config.toggleSprint || !forwardKey.isKeyDown() || Player.isSneaking()) return
-    Player.getPlayer().func_70031_b(true)
+if (!Config.toggleSprint) return
+    net.minecraft.client.settings.KeyBinding.func_74510_a(Client.getMinecraft().field_71474_y.field_151444_V.func_151463_i(), true)
 })
 
 register("dragged", (mx, my, x, y) => {

--- a/Bloom/features/ToggleSprint.js
+++ b/Bloom/features/ToggleSprint.js
@@ -2,11 +2,11 @@ import { registerWhen } from "../../BloomCore/utils/Utils"
 import Config from "../Config"
 import { data } from "../utils/Utils"
 
-export const forwardKey = new KeyBind(Client.getMinecraft().field_71474_y.field_74351_w)
+const sprintKey = new KeyBind(Client.getMinecraft().field_71474_y.field_151444_V)
 
 register("tick", () => {
-if (!Config.toggleSprint) return
-    net.minecraft.client.settings.KeyBinding.func_74510_a(Client.getMinecraft().field_71474_y.field_151444_V.func_151463_i(), true)
+    if (!Config.toggleSprint) return
+    sprintKey.setState(true)
 })
 
 register("dragged", (mx, my, x, y) => {


### PR DESCRIPTION
The way the toggle sprint worked before could have caused bans as it keeps sprinting while using items which is really easy to check for anticheats, I have changed the code to:
`KeyBinding.setKeyBindState(mc.gameSettings.keyBindSprint.getKeyCode(), true);`
which just holds the sprinting key
