### PR TITLE
Add more features to the /ds and //kuudra commands

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -1009,6 +1009,14 @@ class Config {
         subcategory: "Stats"
     })
     autoDSParty = false;
+
+    @SwitchProperty({
+        name: "Advanced /ds and //kuudra",
+        description: "/ds and //kuudra will show extra player statistics",
+        category: "Party Finder",
+        subcategory: "Stats"
+    })
+    advancedDS = false;
     
     // ---------------------------------------------------------------
     // Chest Profit

--- a/commands/DsCommand.js
+++ b/commands/DsCommand.js
@@ -191,8 +191,8 @@ export const dsCommand = register("command", (player) => {
                 }
 
                 extraComponents = [
+                    columnSeparator,new TextComponent(`&cS+`).setHover("show_text", `&cS+ Runs${getTimes("fastest_time_s_plus")}`),
                     columnSeparator,new TextComponent(`&cS`).setHover("show_text", `&cS Runs${getTimes("fastest_time_s")}`),
-                    columnSeparator,new TextComponent(`&cS+`).setHover("show_text", `&cS Runs${getTimes("fastest_time_s_plus")}`),
                     "\n",
                     new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover),columnSeparator
                 ];

--- a/commands/DsCommand.js
+++ b/commands/DsCommand.js
@@ -20,12 +20,6 @@ const columnSeparator = ` &8| `
 
 const prettifyLevel = (level) => level == 120 ? `&b&l${level}` : level >= 50 ? `&6&l${level}` : `${level}`
 
-function rightPadNumber(str, len) {
-    if (str.length >= len) return str
-    if (len - str.length > 2) len += 1
-    return str + " ".repeat(len - str.length)
-}
-
 const padWithCommas = (string, maxLength) => {
     const toAdd = Math.floor((maxLength - Renderer.getStringWidth(string)) / Renderer.getStringWidth(invisComma))
     return string + invisComma.repeat(toAdd)

--- a/commands/DsCommand.js
+++ b/commands/DsCommand.js
@@ -4,6 +4,17 @@ import { getHypixelPlayer, getHypixelPlayerV2, getMojangInfo, getPlayerUUID, get
 import { bcData, calcSkillLevel, convertToPBTime, fn, getRank } from "../../BloomCore/utils/Utils"
 import Promise from "../../PromiseV2"
 import { prefix } from "../utils/Utils"
+import {getMpInfo, getSpiritPetStatus, getGdragStatus, getSelectedArrows, getSbLevelInfo} from "../utils/ProfileInfoCommons"
+import Config from "../Config"
+
+function rightpadNumber(str, len) {
+    if (str.length >= len) return str
+    if (len - str.length > 2) len += 1
+    return str + " ".repeat(len - str.length)
+}
+
+const invisComma = "&0,"
+const columnSeparator = ` &8| `;
 
 export const dsCommand = register("command", (player) => {
     if (!bcData.apiKey) return ChatLib.chat(`${prefix} &cError: API Key not set! Set it with &b/bl setkey <key>`)
@@ -19,21 +30,25 @@ export const dsCommand = register("command", (player) => {
             getHypixelPlayerV2(uuid),
             getSelectedProfileV2(uuid)
         ]).then(values => {
-            const [playerInfo, sbProfile] = values
+            let [playerInfo, sbProfile] = values
 
             if (!playerInfo) return ChatLib.chat(`${prefix} &cCouldn't get player info for ${player}`)
             if (!sbProfile) return ChatLib.chat(`${prefix} &cCouldn't get ${player}'s Skyblock profile!`)
             
             const playerName = playerInfo.player.displayname
             let nameFormatted = `${getRank(playerInfo)} ${playerName}&r`
-            if (!Object.keys(sbProfile.members[uuid].dungeons.dungeon_types.catacombs).length) return ChatLib.chat(`${prefix} &c${playerName} has never entered the Catacombs!`)
             let profileName = sbProfile["cute_name"]
-            const secretsFound = playerInfo.player?.achievements?.skyblock_treasure_hunter || 0
-            const profileSecrets = sbProfile.members[uuid]?.dungeons?.secrets || 0
+            if (!sbProfile.members[uuid]) return ChatLib.chat(`${prefix} &cCouldn't get ${player}'s Skyblock profile!`);
+            sbProfile.members[uuid].banking = sbProfile.banking
+            sbProfile = sbProfile.members[uuid];
             
-            let dung = sbProfile.members[uuid].dungeons
-            let master = sbProfile.members[uuid].dungeons.dungeon_types.master_catacombs ?? null
-            let cata = sbProfile.members[uuid].dungeons.dungeon_types.catacombs
+            if (!Object.keys(sbProfile.dungeons.dungeon_types.catacombs).length) return ChatLib.chat(`${prefix} &c${playerName} has never entered the Catacombs!`)
+            const secretsFound = playerInfo.player?.achievements?.skyblock_treasure_hunter || 0
+            const profileSecrets = sbProfile?.dungeons?.secrets || 0
+            
+            let dung = sbProfile.dungeons
+            let master = sbProfile.dungeons.dungeon_types.master_catacombs ?? null
+            let cata = sbProfile.dungeons.dungeon_types.catacombs
             
             let selectedClass = dung.selected_dungeon_class
     
@@ -44,9 +59,7 @@ export const dsCommand = register("command", (player) => {
             let cataLevelInt = Math.floor(cataLevel)
             let cataLevelStr = prettify(cataLevel)
             let cataLow = cataLevel > 50 ? 50 : cataLevelInt
-            
-            let totalNormal = 0
-            let totalMaster = 0
+        
             
             const classWithSymbols = {
                 "mage":"⚚ Mage",
@@ -70,18 +83,6 @@ export const dsCommand = register("command", (player) => {
             let classAverage = Math.round(classLvls.reduce((a, b) => a + b) / classLvls.length * 100) / 100
             nameHover += `\n\n&cClass Average: ` + (classAverage == 50 ? `&6&l${classAverage}` : `&e${classAverage}`)
             nameHover += `\n\n&d&lSkyCrypt &7(Click)\n&ahttps://sky.shiiyu.moe/stats/${playerName}`
-            const getCompHover = () => {
-                let str = "&cCompletions"
-                for (let floor = 1; floor <= 7; floor++) {
-                    let comps = cata["tier_completions"][floor] == undefined ? 0 : cata["tier_completions"][floor]
-                    let masterComps = master && "tier_completions" in master ? master.tier_completions[floor] == undefined ? "" : master.tier_completions[floor] : ""
-                    let masterStr = masterComps == "" ? "" : ` &8| &c${master.tier_completions[floor]}`
-                    totalNormal += comps
-                    totalMaster += masterComps == "" ? 0 : masterComps
-                    str += `\n&e${floor}] &a${fn(comps)}${masterStr}`
-                }
-                return str
-            }
 
             let xpNext = catacombs[cataLow+1] - catacombs[cataLow]
             xpNext = isNaN(xpNext) ? 0 : xpNext
@@ -95,39 +96,125 @@ export const dsCommand = register("command", (player) => {
 
             if (cataLevel > 50) cataHover += `\n&cProgress: &6${fn((cataXP - catacombs[50])%2e8)}&c/&6200,000,000`
 
-            let compHover = getCompHover() + `\n&a${fn(totalNormal)}`
-            compHover += totalMaster == 0 ? "" :  ` &8| &c${fn(totalMaster)}`
-            compHover += `\n&aTotal: &e${fn(totalNormal + totalMaster)}`
+            let totalNormal = 0
+            let totalMaster = 0
+            const getCompHover = () => {
+                const timeKey = "fastest_time_s_plus"
+
+                let normalComps = [];
+                let mmComps = [];
+                let normalPbs = [];
+                let mmPbs = [];
+                let str = "&cCompletions" + columnSeparator + "&cS+"
+                for (let floor = 1; floor <= 7; floor++) {
+                    let comps = cata["tier_completions"][floor] == undefined ? 0 : cata["tier_completions"][floor]
+                    let masterComps = master && master["tier_completions"][floor] == undefined ? 0 : master["tier_completions"][floor]
+                    normalComps.push(comps);
+                    mmComps.push(masterComps)
+
+                    totalNormal += comps
+                    totalMaster += masterComps == "" ? 0 : masterComps
+
+                    let normalTime = timeKey in cata ? cata[timeKey][floor] == undefined ? null : cata[timeKey][floor] : null
+                    let masterTime = master && timeKey in master ? master[timeKey][floor] == undefined ? null : master[timeKey][floor] : null
+                    normalPbs.push(normalTime)
+                    mmPbs.push(masterTime)
+                }
+
+                const maxNormalLength = fn(normalComps.reduce((a, b) => a > b ? a : b))?.length ?? 0
+                const maxMasterLength = fn(mmComps.reduce((a, b) => a > b ? a : b))?.length ?? 0
+                const maxNormalPbLength = normalPbs.reduce((a, b) => a > b ? a : b)?.toString()?.length ?? 0
+                const maxMasterPbLength = mmPbs.reduce((a, b) => a > b ? a : b)?.toString()?.length ?? 0
+                
+                for(let floor = 0; floor <= 6; floor++) {
+                    let normalTime = normalPbs[floor]
+                    let masterTime = mmPbs[floor]
+
+                    str += `\n&e${floor+1}] &a${
+                        rightpadNumber(fn(normalComps[floor]),maxNormalLength) + (normalComps[floor] < 1000 && maxNormalLength>4 ? invisComma : "")
+                    }`
+                    str += " &8- "
+                    if (!normalTime) {
+                        str += "&80:00"
+                    } else {
+                        str += `&a${
+                            convertToPBTime(normalTime)
+                            + (maxNormalPbLength > 3 && normalTime < 600 ? " " : "")
+                        }`
+                    }
+
+                    str += columnSeparator
+
+                    str += `&c${
+                        rightpadNumber(fn(mmComps[floor]),maxMasterLength)
+                        + (mmComps[floor] < 1000 && maxMasterLength > 4 ? invisComma : "")}`
+                    str += " &8- "
+                    if (!masterTime) {
+                        str += "&80:00"
+                    } else {
+                        str += `&c${
+                            convertToPBTime(masterTime)
+                            + (maxMasterPbLength > 3 && masterTime < 600 ? " " : "")
+                        }`
+                    }
+
+                }
+                str += `\n&a${fn(totalNormal)}${columnSeparator}&c${fn(totalMaster)}`
+                str += `\n&aTotal: &e${fn(totalNormal + totalMaster)}`
+                return str;
+            }
+            
+            let compHover = getCompHover()
             
             let secretsHover = `&e&nSecrets\n` +
             `&aTotal: &e${fn(secretsFound)}\n` +
-            `&eProfile: ${fn(profileSecrets)}\n` +
+            (profileSecrets && profileSecrets !== secretsFound ? `&aProfile: &e${fn(profileSecrets)}\n` : "") +
             `&aSecrets/Run: &e${(secretsFound / (totalNormal + totalMaster)).toFixed(2)}`
 
-            const getTimes = (key) => {
-                let str = ""
-                for (let floor = 1; floor <= 7; floor++) {
-                    let normalTime = key in cata ? cata[key][floor] == undefined ? null : cata[key][floor] : null
-                    let masterTime = master && key in master ? master[key][floor] == undefined ? null : master[key][floor] : null
-                    
-                    let masterStr = masterTime == null ? "" : ` &8| &c${convertToPBTime(masterTime)}`
-                    str += `\n&e${floor}] &a${convertToPBTime(normalTime)}${masterStr}`
+            const {mp,mpHover} = getMpInfo(sbProfile)
+
+            let extraComponents = [];
+
+            if (!Config.advancedDS) {
+                extraComponents = [columnSeparator,new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover)];
+            } else {
+                const getTimes = (key) => {
+                    let str = ""
+                    for (let floor = 1; floor <= 7; floor++) {
+                        let normalTime = key in cata ? cata[key][floor] == undefined ? null : cata[key][floor] : null
+                        let masterTime = master && key in master ? master[key][floor] == undefined ? null : master[key][floor] : null
+                        
+                        let masterStr = masterTime == null ? "" : ` &8| &c${convertToPBTime(masterTime)}`
+                        str += `\n&e${floor}] &a${convertToPBTime(normalTime)}${masterStr}`
+                    }
+                    return str
                 }
-                return str
+
+                extraComponents = [
+                    columnSeparator,new TextComponent(`&cS`).setHover("show_text", `&cS Runs${getTimes("fastest_time_s")}`),
+                    columnSeparator,new TextComponent(`&cS+`).setHover("show_text", `&cS Runs${getTimes("fastest_time_s_plus")}`),
+                    "\n",
+                    new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover),columnSeparator
+                ];
+
+                extraComponents.push(new TextComponent(getSbLevelInfo(sbProfile)), columnSeparator)
+
+                const {spirit,spiritText} = getSpiritPetStatus(sbProfile)
+                extraComponents.push( new TextComponent(spiritText).setHover("show_text",`&cSpirit pet: ${ spirit ? "&aYes" : "&cNo" }`), columnSeparator)
+
+                const {gdragText,gdragHover} = getGdragStatus(sbProfile)
+                extraComponents.push( new TextComponent(gdragText).setHover("show_text",gdragHover), columnSeparator)
+
+                extraComponents.push(new TextComponent(getSelectedArrows(sbProfile)))
             }
 
-            let sPlusHover = `&cS+ Runs${getTimes("fastest_time_s_plus")}`
-            let sHover = `&cS Runs${getTimes("fastest_time_s")}`
-            
-            // toDelete.push(lineID)
-
             new Message(
-                new TextComponent(`${nameFormatted}`).setHover("show_text", nameHover).setClick("open_url", `https://sky.shiiyu.moe/stats/${playerName}`), ` &8| `,
-                new TextComponent(`&c${cataLevelStr}`).setHover("show_text", cataHover), ` &8| `,
-                new TextComponent(`&e${fn(secretsFound)}`).setHover("show_text", secretsHover), ` &8| `,
-                new TextComponent(`&cCompletions`).setHover("show_text", compHover), ` &8| `,
-                new TextComponent(`&cS+`).setHover("show_text", sPlusHover), ` &8| `,
-                new TextComponent(`&cS`).setHover("show_text", sHover)
+                new TextComponent(`${nameFormatted}`).setHover("show_text", nameHover).setClick("open_url", `https://sky.shiiyu.moe/stats/${playerName}`), columnSeparator,
+                new TextComponent(`&c${cataLevelStr}`).setHover("show_text", cataHover), columnSeparator,
+                new TextComponent(`&e${fn(secretsFound)}`).setHover("show_text", secretsHover), columnSeparator,
+                new TextComponent(`&cRuns`).setHover("show_text", compHover),
+                ...extraComponents
+                // new TextComponent(`&cS`).setHover("show_text", sHover), columnSeparator,
             ).chat()
 
         }).catch(e => ChatLib.chat(`${prefix} &cError getting Dungeon Stats for ${player}: ${e}`))

--- a/commands/DsCommand.js
+++ b/commands/DsCommand.js
@@ -1,26 +1,196 @@
 import Party from "../../BloomCore/Party"
 import { catacombs } from "../../BloomCore/skills/catacombs"
-import { getHypixelPlayer, getHypixelPlayerV2, getMojangInfo, getPlayerUUID, getProfileByID, getRecentProfile, getSelectedProfileV2 } from "../../BloomCore/utils/APIWrappers"
+import { getHypixelPlayerV2, getPlayerUUID, getSelectedProfileV2 } from "../../BloomCore/utils/APIWrappers"
 import { bcData, calcSkillLevel, convertToPBTime, fn, getRank } from "../../BloomCore/utils/Utils"
 import Promise from "../../PromiseV2"
 import { prefix } from "../utils/Utils"
 import {getMpInfo, getSpiritPetStatus, getGdragStatus, getSelectedArrows, getSbLevelInfo} from "../utils/ProfileInfoCommons"
 import Config from "../Config"
 
-function rightpadNumber(str, len) {
+const classWithSymbols = {
+    "mage": "⚚ Mage",
+    "healer": "☤ Healer",
+    "archer": "➶ Archer",
+    "tank": "። Tank",
+    "berserk": "⚔ Berserk"
+}
+
+const invisComma = "&0,"
+const columnSeparator = ` &8| `
+
+const prettifyLevel = (level) => level == 120 ? `&b&l${level}` : level >= 50 ? `&6&l${level}` : `${level}`
+
+function rightPadNumber(str, len) {
     if (str.length >= len) return str
     if (len - str.length > 2) len += 1
     return str + " ".repeat(len - str.length)
 }
 
-const invisComma = "&0,"
-const columnSeparator = ` &8| `;
+const padWithCommas = (string, maxLength) => {
+    const toAdd = Math.floor((maxLength - Renderer.getStringWidth(string)) / Renderer.getStringWidth(invisComma))
+    return string + invisComma.repeat(toAdd)
+}
+
+/**
+ * Inserts black commas at the end of each string in the array until they are all equal length
+ * @param {String[]} stringsArr 
+ * @returns {String[]}
+ */
+const padStrings = (stringsArr) => {
+    const maxLength = Math.max(...stringsArr.map(v => Renderer.getStringWidth(v)))
+
+    return stringsArr.map(v => padWithCommas(v, maxLength))
+
+}
+
+const getFormattedTime = (timeMs, isMM) => {
+    if (!timeMs) return "&8??:??"
+
+    const formatted = convertToPBTime(timeMs)
+
+    if (isMM) return "&c" + formatted
+    return "&a" + formatted
+}
+
+const getFormattedComps = (comps, isMM) => {
+    if (!comps) return "&80"
+    
+    if (isMM) return "&c" + fn(comps)
+    return "&a" + fn(comps)
+}
+
+// |   Comps    |     S+     |      S      |
+// 1] 46   9    | 2:08  2:19 | 2:28  ??:?? |
+// 2] 56   4    | 2:20  5:11 | 2:09  3:30  |
+// 3] 1    24   | ??:?? 3:34 | ??:?? 2:37  |
+// 4] 22   2    | 4:14  4:26 | 3:17  6:31  |
+// 5] 4589 1138 | 1:41  1:41 | 2:03  2:04  |
+// 6] 504  272  | 2:31  2:27 | 2:49  2:34  |
+// 7] 385  1    | 4:16  9:16 | 4:26  ??:?? |
+/**
+ * 
+ * @param {*} compMatrix - Example above, 6x7 matrix of comps, pbs etc. Having them all in a neat little matrix makes formatting it all much easier
+ */
+const getCompInfo = (dungeonObject) => {
+    const { matrix, normalComps, masterComps } = createCompMatrix(dungeonObject)
+    const totalComps = normalComps + masterComps
+
+    const finalArr = new Array(8).fill("") // 8 instead of 7 because of the column titles
+
+    const colTitles = ["&eComps", "&eS+", "&eS"]
+
+    // Go by columns first instead of rows since we need to build the strings from left to right
+    for (let col = 0; col < matrix[0].length; col++) {
+        // Get all of the strings for this column and pad them
+        let paddedStrings = padStrings(matrix.map(v => v[col]))
+
+        for (let i = 0; i < paddedStrings.length; i++) {
+            // Insert the floor number into the start of the line
+            if (col == 0) finalArr[i+1] += `&e${i+1}] `
+
+            // Separator every two columns
+            if (col % 2 == 0 && col !== 0) {
+                finalArr[i+1] += columnSeparator
+            }
+
+            // And add the data for this floor
+            finalArr[i+1] += paddedStrings[i]
+        }
+
+        // Insert the title and center it in the column. This whole block is just for a centered fucking header
+        if (col % 2 == 1) {
+            finalArr[0] += columnSeparator
+            
+            let title = colTitles.shift()
+            let titleWidth = Renderer.getStringWidth(title)
+            let existingWidth = Renderer.getStringWidth(finalArr[0]) // How long the top line is already
+            let maxWidth = Math.max(...finalArr.map(a => Renderer.getStringWidth(a))) // The target width
+
+            // How much space should be taken up by commas in total on L + R
+            let spaceToFill = maxWidth - existingWidth - titleWidth
+            // Amount of comma space each side
+            let sideSpace = Math.floor((spaceToFill) / 2)
+
+            // Insert the centered column title
+            finalArr[0] = padWithCommas(finalArr[0], existingWidth + sideSpace)
+            finalArr[0] += title
+            finalArr[0] = padWithCommas(finalArr[0], maxWidth)
+        }
+    }
+
+    // Combine the string and add the total completions at the bottom of it
+    let compHover = finalArr.join("\n")
+    compHover += `\n&aCompletions: &a${fn(normalComps)} &8| &c${fn(masterComps)}`
+    compHover += `\n&aOverall: &e${fn(totalComps)}`
+
+    return {
+        compHover,
+        normalComps,
+        masterComps
+    }
+}
+
+/**
+ * Final result will be a 6x7 matrix of all strings
+ * [
+ *     [NORMAL_COMP, MM_COMP, NORM_S_PLUS_PB, MM_S_PLUS_PB, NORM_S_PB, MM_S_PB], // Floor 1
+ *     [NORMAL_COMP, MM_COMP, NORM_S_PLUS_PB, MM_S_PLUS_PB, NORM_S_PB, MM_S_PB], // Floor 2
+ *     [] ... // 3
+ *     [] ... // 4
+ *     [] ... // 5
+ *     [] ... // 6
+ *     [] ... // 6
+ * ]
+ * @param {Object} dungeonDataObj - Object containing the matrix, normal comps, and mm comps
+ */
+const createCompMatrix = (dungeonDataObj) => {
+
+    const matrix = new Array(7).fill(null) // Create a 6x7 matrix of nulls
+    matrix.forEach((_, i) => matrix[i] = new Array(6).fill(null))
+    
+    const normal = dungeonDataObj.dungeon_types.catacombs
+    const mm = dungeonDataObj.dungeon_types.master_catacombs
+
+    let normalComps = 0
+    let masterComps = 0
+
+    // Start populating the matrix
+    for (let floorIndex = 0; floorIndex < matrix.length; floorIndex++) {
+        // Stats for this floor get inserted into the matrix
+        // I fucking hate this
+        let normComps = (normal && "tier_completions" in normal ? normal.tier_completions[floorIndex+1] : null) ?? 0
+        let mmComps = (mm && "tier_completions" in mm ? mm.tier_completions[floorIndex+1] : null) ?? 0
+        matrix[floorIndex][0] = `&a${getFormattedComps(normComps)}  `
+        matrix[floorIndex][1] = `&c${getFormattedComps(mmComps, true)} `
+        normalComps += normComps
+        masterComps += mmComps
+        
+        let normSPlus = (normal && "fastest_time_s_plus" in normal ? normal.fastest_time_s_plus[floorIndex+1] : null) ?? 0
+        let mmSPlus = (mm && "fastest_time_s_plus" in mm ? mm.fastest_time_s_plus[floorIndex+1] : null) ?? 0
+        matrix[floorIndex][2] = `&a${getFormattedTime(normSPlus)}  `
+        matrix[floorIndex][3] = `&c${getFormattedTime(mmSPlus, true)} `
+        
+        let normS = (normal && "fastest_time_s" in normal ? normal.fastest_time_s[floorIndex+1] : null) ?? 0
+        let mmS = (mm && "fastest_time_s" in mm ? mm.fastest_time_s[floorIndex+1] : null) ?? 0
+        matrix[floorIndex][4] = `&a${getFormattedTime(normS)}  `
+        matrix[floorIndex][5] = `&c${getFormattedTime(mmS, true)} `
+    }
+
+    return {
+        matrix,
+        normalComps,
+        masterComps
+    }
+}
 
 export const dsCommand = register("command", (player) => {
     if (!bcData.apiKey) return ChatLib.chat(`${prefix} &cError: API Key not set! Set it with &b/bl setkey <key>`)
     if (player == "p") {
         ChatLib.chat(`${prefix} &aRunning /ds on all party members...`)
-        Object.keys(Party.members).filter(a => a !== Player.getName()).forEach(a => ChatLib.command(`ds ${a}`, true))
+        Object.keys(Party.members).forEach(a => {
+            if (a == Player.getName()) return
+            ChatLib.command(`ds ${a}`, true)
+        })
         return
     }
 	if (!player) player = Player.getName()
@@ -38,9 +208,9 @@ export const dsCommand = register("command", (player) => {
             const playerName = playerInfo.player.displayname
             let nameFormatted = `${getRank(playerInfo)} ${playerName}&r`
             let profileName = sbProfile["cute_name"]
-            if (!sbProfile.members[uuid]) return ChatLib.chat(`${prefix} &cCouldn't get ${player}'s Skyblock profile!`);
+            if (!sbProfile.members[uuid]) return ChatLib.chat(`${prefix} &cCouldn't get ${player}'s Skyblock profile!`)
             sbProfile.members[uuid].banking = sbProfile.banking
-            sbProfile = sbProfile.members[uuid];
+            sbProfile = sbProfile.members[uuid]
             
             if (!Object.keys(sbProfile.dungeons.dungeon_types.catacombs).length) return ChatLib.chat(`${prefix} &c${playerName} has never entered the Catacombs!`)
             const secretsFound = playerInfo.player?.achievements?.skyblock_treasure_hunter || 0
@@ -52,22 +222,11 @@ export const dsCommand = register("command", (player) => {
             
             let selectedClass = dung.selected_dungeon_class
     
-            const prettify = (level) => level == 120 ? `&b&l${level}` : level >= 50 ? `&6&l${level}` : `${level}`
-            
             let cataXP = Math.floor(cata["experience"])
             let cataLevel = calcSkillLevel("catacombs", cataXP)
             let cataLevelInt = Math.floor(cataLevel)
-            let cataLevelStr = prettify(cataLevel)
+            let cataLevelStr = prettifyLevel(cataLevel)
             let cataLow = cataLevel > 50 ? 50 : cataLevelInt
-        
-            
-            const classWithSymbols = {
-                "mage":"⚚ Mage",
-                "healer":"☤ Healer",
-                "archer":"➶ Archer",
-                "tank":"። Tank",
-                "berserk":"⚔ Berserk"
-            }
             
             let nameHover = `${nameFormatted} &a- &e${profileName}`
             let classLvls = []
@@ -77,7 +236,7 @@ export const dsCommand = register("command", (player) => {
                 classLvls.push(classLvl)
                 let xpCurr = classLvl >= 50 ? (classXP - catacombs[50])%2e8 : parseInt(classXP - catacombs[parseInt(classLvl)])
                 let xpNext = classLvl >= 50 ? 2e8 : catacombs[parseInt(classLvl)+1] - catacombs[parseInt(classLvl)] || 0
-                nameHover += `\n${classs == selectedClass ? "&a" : "&c"}${classWithSymbols[classs]} - &e${prettify(classLvl)}    &a(&6${fn(xpCurr)}&a/&6${fn(xpNext)}&a)`
+                nameHover += `\n${classs == selectedClass ? "&a" : "&c"}${classWithSymbols[classs]} - &e${prettifyLevel(classLvl)}    &a(&6${fn(xpCurr)}&a/&6${fn(xpNext)}&a)`
                 
             })
             let classAverage = Math.round(classLvls.reduce((a, b) => a + b) / classLvls.length * 100) / 100
@@ -96,116 +255,34 @@ export const dsCommand = register("command", (player) => {
 
             if (cataLevel > 50) cataHover += `\n&cProgress: &6${fn((cataXP - catacombs[50])%2e8)}&c/&6200,000,000`
 
-            let totalNormal = 0
-            let totalMaster = 0
-            const getCompHover = () => {
-                const timeKey = "fastest_time_s_plus"
+            const { compHover, normalComps, masterComps } = getCompInfo(dung)
 
-                let normalComps = [];
-                let mmComps = [];
-                let normalPbs = [];
-                let mmPbs = [];
-                let str = "&cCompletions" + columnSeparator + "&cS+"
-                for (let floor = 1; floor <= 7; floor++) {
-                    let comps = cata["tier_completions"][floor] == undefined ? 0 : cata["tier_completions"][floor]
-                    let masterComps = master && master["tier_completions"][floor] == undefined ? 0 : master["tier_completions"][floor]
-                    normalComps.push(comps);
-                    mmComps.push(masterComps)
-
-                    totalNormal += comps
-                    totalMaster += masterComps == "" ? 0 : masterComps
-
-                    let normalTime = timeKey in cata ? cata[timeKey][floor] == undefined ? null : cata[timeKey][floor] : null
-                    let masterTime = master && timeKey in master ? master[timeKey][floor] == undefined ? null : master[timeKey][floor] : null
-                    normalPbs.push(normalTime)
-                    mmPbs.push(masterTime)
-                }
-
-                const maxNormalLength = fn(normalComps.reduce((a, b) => a > b ? a : b))?.length ?? 0
-                const maxMasterLength = fn(mmComps.reduce((a, b) => a > b ? a : b))?.length ?? 0
-                const maxNormalPbLength = normalPbs.reduce((a, b) => a > b ? a : b)?.toString()?.length ?? 0
-                const maxMasterPbLength = mmPbs.reduce((a, b) => a > b ? a : b)?.toString()?.length ?? 0
-                
-                for(let floor = 0; floor <= 6; floor++) {
-                    let normalTime = normalPbs[floor]
-                    let masterTime = mmPbs[floor]
-
-                    str += `\n&e${floor+1}] &a${
-                        rightpadNumber(fn(normalComps[floor]),maxNormalLength) + (normalComps[floor] < 1000 && maxNormalLength>4 ? invisComma : "")
-                    }`
-                    str += " &8- "
-                    if (!normalTime) {
-                        str += "&80:00"
-                    } else {
-                        str += `&a${
-                            convertToPBTime(normalTime)
-                            + (maxNormalPbLength > 3 && normalTime < 600 ? " " : "")
-                        }`
-                    }
-
-                    str += columnSeparator
-
-                    str += `&c${
-                        rightpadNumber(fn(mmComps[floor]),maxMasterLength)
-                        + (mmComps[floor] < 1000 && maxMasterLength > 4 ? invisComma : "")}`
-                    str += " &8- "
-                    if (!masterTime) {
-                        str += "&80:00"
-                    } else {
-                        str += `&c${
-                            convertToPBTime(masterTime)
-                            + (maxMasterPbLength > 3 && masterTime < 600 ? " " : "")
-                        }`
-                    }
-
-                }
-                str += `\n&a${fn(totalNormal)}${columnSeparator}&c${fn(totalMaster)}`
-                str += `\n&aTotal: &e${fn(totalNormal + totalMaster)}`
-                return str;
-            }
-            
-            let compHover = getCompHover()
-            
             let secretsHover = `&e&nSecrets\n` +
             `&aTotal: &e${fn(secretsFound)}\n` +
             (profileSecrets && profileSecrets !== secretsFound ? `&aProfile: &e${fn(profileSecrets)}\n` : "") +
-            `&aSecrets/Run: &e${(secretsFound / (totalNormal + totalMaster)).toFixed(2)}`
+            `&aSecrets/Run: &e${(secretsFound / (normalComps + masterComps)).toFixed(2)}`
 
-            const {mp,mpHover} = getMpInfo(sbProfile)
+            const { mp, mpHover } = getMpInfo(sbProfile)
 
-            let extraComponents = [];
+            const extraComponents = [
+                columnSeparator,
+                new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover)
+            ]
 
-            if (!Config.advancedDS) {
-                extraComponents = [columnSeparator,new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover)];
-            } else {
-                const getTimes = (key) => {
-                    let str = ""
-                    for (let floor = 1; floor <= 7; floor++) {
-                        let normalTime = key in cata ? cata[key][floor] == undefined ? null : cata[key][floor] : null
-                        let masterTime = master && key in master ? master[key][floor] == undefined ? null : master[key][floor] : null
-                        
-                        let masterStr = masterTime == null ? "" : ` &8| &c${convertToPBTime(masterTime)}`
-                        str += `\n&e${floor}] &a${convertToPBTime(normalTime)}${masterStr}`
-                    }
-                    return str
-                }
-
-                extraComponents = [
-                    columnSeparator,new TextComponent(`&cS+`).setHover("show_text", `&cS+ Runs${getTimes("fastest_time_s_plus")}`),
-                    columnSeparator,new TextComponent(`&cS`).setHover("show_text", `&cS Runs${getTimes("fastest_time_s")}`),
-                    "\n",
-                    new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover),columnSeparator
-                ];
-
-                extraComponents.push(new TextComponent(getSbLevelInfo(sbProfile)), columnSeparator)
-
-                const {spirit,spiritText} = getSpiritPetStatus(sbProfile)
-                extraComponents.push( new TextComponent(spiritText).setHover("show_text",`&cSpirit pet: ${ spirit ? "&aYes" : "&cNo" }`), columnSeparator)
-
-                const {gdragText,gdragHover} = getGdragStatus(sbProfile)
-                extraComponents.push( new TextComponent(gdragText).setHover("show_text",gdragHover), columnSeparator)
-
-                extraComponents.push(new TextComponent(getSelectedArrows(sbProfile)))
+            if (Config.advancedDS) {
+                const { spirit, spiritText } = getSpiritPetStatus(sbProfile)
+                const { gdragText, gdragHover } = getGdragStatus(sbProfile)
+                
+                extraComponents.push(
+                    "\n   ",
+                    new TextComponent(getSbLevelInfo(sbProfile)),
+                    columnSeparator,
+                    new TextComponent(spiritText).setHover("show_text",`&cSpirit pet: ${ spirit ? "&aYes" : "&cNo" }`),
+                    columnSeparator,
+                    new TextComponent(gdragText).setHover("show_text", gdragHover),
+                    columnSeparator,
+                    new TextComponent(getSelectedArrows(sbProfile))
+                )
             }
 
             new Message(

--- a/commands/KuudraCommand.js
+++ b/commands/KuudraCommand.js
@@ -1,5 +1,10 @@
-import { getHypixelPlayer, getMojangInfo, getRecentProfile } from "../../BloomCore/utils/APIWrappers"
+import { getHypixelPlayer, getMojangInfo, getRecentProfile, getSelectedProfileV2 } from "../../BloomCore/utils/APIWrappers"
 import { bcData, fn, getRank } from "../../BloomCore/utils/Utils"
+import { prefix } from "../utils/Utils"
+import Party from "../../BloomCore/Party"
+import { hidePartySpam } from "../../BloomCore/utils/Utils"
+import Config from "../Config"
+import {getMpInfo, getGdragStatus, getSelectedArrows, getSbLevelInfo } from "../utils/ProfileInfoCommons"
 
 const kuudraTiers = {
     "none": "&8Basic",
@@ -8,41 +13,88 @@ const kuudraTiers = {
     "fiery": "&cFiery",
     "infernal": "&4Infernal"
 }
+const columnSeparator = ` &8| `;
 
 export const kuudraCommand = register("command", (player) => {
+    kuudraCommandExec(player)
+}).setName("/kuudra")
+
+function kuudraCommandExec(player) {
+    if (player == "p") {
+        ChatLib.chat(`${prefix} &aRunning //kuudra on all party members...`)
+        Object.keys(Party.members).filter(a => a !== Player.getName()).forEach(a => kuudraCommandExec(a))
+        return
+    }
     if (!player) player = Player.getName()
+	
     
     getMojangInfo(player).then(mojangInfo => {
         if (!mojangInfo) return ChatLib.chat(`&cError: Not a real player!`)
         let {name, id} = mojangInfo
-        getHypixelPlayer(id, bcData.apiKey).then(hypixelInfo => {
+        getHypixelPlayer(id, bcData.apiKey).then((hypixelInfo) => {
             let rank = getRank(hypixelInfo)
-            getRecentProfile(id, null, bcData.apiKey).then(profile => {
-                let data = profile.members[id].nether_island_player_data.kuudra_completed_tiers
-                let totalComps = 0
-                let collection = 0
-                
-                // Add PBs to api pls Hypixel ):
+			getSelectedProfileV2(id).then(profile => {
+					let data = profile.members[id].nether_island_player_data.kuudra_completed_tiers
+					let totalComps = 0
+					let collection = 0
+					
+					// Add PBs to api pls Hypixel ):
+					let hoverStr = Object.keys(kuudraTiers).reduce((a, b, i) => {
+						if (!(b in data)) return a
+						a += `\n${kuudraTiers[b]}&f: &a${fn(data[b])}`
+						totalComps += data[b]
+						collection += (i+1) * data[b]
+						// let high = `highest_wave_${b}`
+						// if (!(high in data)) return a
+						// a += `\n   &7Highest Wave: ${data[high]}`
+						return a
+					}, "&eKuudra Completions")
+					let skyCrypt = `https://sky.shiiyu.moe/stats/${name}`
 
-                let hoverStr = Object.keys(kuudraTiers).reduce((a, b, i) => {
-                    if (!(b in data)) return a
-                    a += `\n${kuudraTiers[b]}&f: &a${fn(data[b])}`
-                    totalComps += data[b]
-                    collection += (i+1) * data[b]
-                    // let high = `highest_wave_${b}`
-                    // if (!(high in data)) return a
-                    // a += `\n   &7Highest Wave: ${data[high]}`
-                    return a
-                }, "&eKuudra Completions")
-                let skyCrypt = `https://sky.shiiyu.moe/stats/${name}`
-                new Message(
-                    new TextComponent(`${rank} ${name}`).setHover("show_text", `&d${skyCrypt}`).setClick("open_url", skyCrypt),
-                    " &8| ",
-                    new TextComponent(`&aCompletions: &e${totalComps}`).setHover("show_text", hoverStr),
-                    " &8| ",
-                    new TextComponent(`&aCollection: ${collection >= 5000 ? "&6&l" : "&e"}${fn(collection)}`)
-                ).chat()
-            }).catch(e => ChatLib.chat(`&cError: ${e}`))
+                    let extraComponents = [];
+
+                    if (data["infernal"]) {
+                        extraComponents.push(columnSeparator,new TextComponent(`&aT5 comps: &e${fn(data["infernal"])}`).setHover("show_text", `&e${fn(collection)} Collection`))
+                    }
+
+                    if (Config.advancedDS) {
+                        const sbProfile = profile.members[id]
+                        const {mp,mpHover} = getMpInfo(sbProfile)
+                        extraComponents.push(
+                            "\n",
+                            new TextComponent(`&cMP: &e${fn(mp)}`).setHover("show_text", mpHover),columnSeparator
+                        )
+                        extraComponents.push(new TextComponent(getSbLevelInfo(sbProfile)), columnSeparator)
+
+                        const {gdragText,gdragHover} = getGdragStatus(sbProfile)
+                        extraComponents.push( new TextComponent(gdragText).setHover("show_text",gdragHover), columnSeparator)
+                        
+                        extraComponents.push(new TextComponent(getSelectedArrows(sbProfile)))
+                    }
+
+					new Message(
+						new TextComponent(`${rank} ${name}`).setHover("show_text", `&d${skyCrypt}`).setClick("open_url", skyCrypt),
+						columnSeparator,
+						new TextComponent(`&aCompletions: &e${totalComps}`).setHover("show_text", hoverStr),
+                        ...extraComponents
+					).chat()
+
+			}).catch(e => ChatLib.chat(`&cError: ${e}`))
         }).catch(e => ChatLib.chat(`&cError: ${e}`))
     }).catch(e => ChatLib.chat(`&cError: ${e}`))
-}).setName("/kuudra")
+}
+
+// Auto DS 
+register("chat", (player, combatLevel) => {
+	if (player === Player.getName()) {
+        if (!Config.autoDSParty) return;
+		new Thread(() => {
+			hidePartySpam(750)
+			ChatLib.command("pl")
+			Thread.sleep(750)
+			kuudraCommandExec(p)
+		}).start()
+	} else if (Config.autoDS) {
+		kuudraCommandExec(player)
+	}
+}).setChatCriteria("Party Finder > ${player} joined the group! (Combat Level ${*})")

--- a/commands/KuudraCommand.js
+++ b/commands/KuudraCommand.js
@@ -88,13 +88,17 @@ function kuudraCommandExec(player) {
 register("chat", (player, combatLevel) => {
 	if (player === Player.getName()) {
         if (!Config.autoDSParty) return;
+        
 		new Thread(() => {
 			hidePartySpam(750)
 			ChatLib.command("pl")
 			Thread.sleep(750)
 			kuudraCommandExec(p)
 		}).start()
-	} else if (Config.autoDS) {
-		kuudraCommandExec(player)
+
+        return
 	}
-}).setChatCriteria("Party Finder > ${player} joined the group! (Combat Level ${*})")
+
+    if (Config.autoDS) kuudraCommandExec(player)
+
+}).setChatCriteria(/^Party Finder > (\w{1,16}) joined the group! \(Combat Level (\d+)\)$/)

--- a/utils/ProfileInfoCommons.js
+++ b/utils/ProfileInfoCommons.js
@@ -40,7 +40,7 @@ export function getSpiritPetStatus(sbProfile) {
 const gdragSymbol = "GDRAG"
 export function getGdragStatus(sbProfile) {
     const gdrags = sbProfile.pets_data?.pets?.filter(a => a.type == "GOLDEN_DRAGON")
-    if (!gdrags || !gdrags.length) return {gdragText: "&c" + gdragSymbol,gdragHover: "&eNo Golden Dragon Pet"}
+    if (!gdrags || !gdrags.length) return {gdragText: "&cNO" + gdragSymbol,gdragHover: "&eNo Golden Dragon Pet"}
     let missingBalance = false
     const bank = sbProfile.banking
     if (bank && bank.balance < 990_000_000) missingBalance = true

--- a/utils/ProfileInfoCommons.js
+++ b/utils/ProfileInfoCommons.js
@@ -1,0 +1,98 @@
+// This file contains helper functions to parse a player's profile information to be used in /ds and //kuudra
+import {fn} from "../../BloomCore/utils/Utils"
+
+export function getMpInfo(sbProfile) {
+    let mp = -1
+    let mpHover = "";
+    let abStorage = sbProfile.accessory_bag_storage;
+    if (abStorage) {
+        mp = abStorage.highest_magical_power || null;
+        let selectedPower = abStorage.selected_power || null;
+        let tunings = abStorage.tuning?.slot_0 || null;
+
+        selectedPower = selectedPower ? (selectedPower.charAt(0).toUpperCase() + selectedPower.slice(1)).replaceAll("_"," ") : "null";
+        mpHover = `&cMagical Power: &e${fn(mp)}\n&cSelected Power: &e${selectedPower}\n&cTuning points: `;
+        let temp = false;
+        if (tunings) {
+            for (let statname in tunings) {
+                if (tunings[statname] != 0) {
+                    if (temp) mpHover += ", ";
+                    mpHover += "&f" + String(tunings[statname]) + " &7" + (statname.charAt(0).toUpperCase() + statname.slice(1)).replaceAll("_"," ")
+                    temp = true
+                }
+            }
+        }
+    }
+
+    return { mp, mpHover }
+}
+
+const spiritSymbol = "⩀"
+export function getSpiritPetStatus(sbProfile) {
+    if (sbProfile.pets_data?.pets?.some(a => a.type == "SPIRIT" && a.tier == "LEGENDARY")) {
+		return {spirit: true,spiritText: "&a" + spiritSymbol}
+	} else {
+        return {spirit: false,spiritText: "&c" + spiritSymbol + " &0&lNO SPIRIT"}
+    }
+}
+
+const gdragSymbol = "GDRAG"
+export function getGdragStatus(sbProfile) {
+    const gdrags = sbProfile.pets_data?.pets?.filter(a => a.type == "GOLDEN_DRAGON")
+    if (!gdrags || !gdrags.length) return {gdragText: "&c" + gdragSymbol,gdragHover: "&eNo Golden Dragon Pet"}
+    let missingBalance = false;
+    const bank = sbProfile.banking;
+    if (bank && bank.balance < 990_000_000) missingBalance = true;
+
+
+    let hasLevel200 = false;
+    let shelmetGdrag = false;
+    let remediesGdrag = false;
+    let relicGdrag = false;
+    for(let g of gdrags) {
+        if (g.exp > 210_255_385) hasLevel200 = true;
+        if (g.heldItem === "DWARF_TURTLE_SHELMET") shelmetGdrag = true;
+        if (g.heldItem === "ANTIQUE_REMEDIES") remediesGdrag = true;
+        if (g.heldItem === "MINOS_RELIC") relicGdrag = true;
+    }
+
+    if (missingBalance) {
+        return {gdragText: "&4" + (gdrags.length > 1 ? (gdrags.length+" ") : "") + gdragSymbol,gdragHover: `&e${gdrags.length} Golden Dragon Pets&r\n&cOnly ${fn(Math.floor(bank.balance))} in bank${!hasLevel200 ? "\n\n&cNo Level 200" : ""}`};
+    }
+
+    return {gdragText: (hasLevel200 ? "&a" : "&4") + (gdrags.length > 1 ? (gdrags.length+" ") : "") + gdragSymbol,gdragHover: `&e${gdrags.length} Golden Dragon Pets&r\n${shelmetGdrag ? "&a" : "&c"}Dwarf Turtle Shelmet\n${remediesGdrag ? "&a" : "&c"}Antique Remedies\n${relicGdrag ? "&a" : "&c"}Minos Relic${!hasLevel200 ? "\n\n&cNo Level 200" : ""}`};
+}
+
+const arrowSymbol = "↣"
+export function getSelectedArrows(sbProfile) {
+    let arrow = sbProfile.item_data?.favorite_arrow;
+    if (!arrow) return "&c" + arrowSymbol + " No Arrow Selected";
+
+    arrow = arrow.replace("ARROW","").replaceAll("_"," ").toLowerCase().split(" ").map(a => a.charAt(0).toUpperCase() + a.slice(1)).join(" ");
+    if (arrow === "Armorshred") arrow = "Shred"
+    return "&c" + arrowSymbol + " &e" + arrow;
+}
+
+export function getSbLevelInfo(sbProfile) {
+    let level = sbProfile.leveling?.experience;
+    if (!level) level = 0;
+    level = Math.floor(level/100);
+    level = `&f&l[${getLevelColor(level)}${level}&r&f]`
+    return level;
+}
+
+
+function getLevelColor(level) {
+	if (level < 80) return "&f";
+	if (level < 160) return "&a";
+	if (level < 200) return "&2";
+	if (level < 240) return "&b";
+	if (level < 280) return "&3";
+	if (level < 320) return "&9";
+	if (level < 360) return "&d";
+	if (level < 400) return "&5";
+	if (level < 440) return "&6";
+	if (level < 120) return "&e";
+	if (level < 480) return "&c";
+	return "&4";
+}

--- a/utils/ProfileInfoCommons.js
+++ b/utils/ProfileInfoCommons.js
@@ -1,26 +1,27 @@
 // This file contains helper functions to parse a player's profile information to be used in /ds and //kuudra
-import {fn} from "../../BloomCore/utils/Utils"
+import { fn, title } from "../../BloomCore/utils/Utils"
 
 export function getMpInfo(sbProfile) {
     let mp = -1
-    let mpHover = "";
-    let abStorage = sbProfile.accessory_bag_storage;
-    if (abStorage) {
-        mp = abStorage.highest_magical_power || null;
-        let selectedPower = abStorage.selected_power || null;
-        let tunings = abStorage.tuning?.slot_0 || null;
+    let mpHover = ""
+    let abStorage = sbProfile.accessory_bag_storage
 
-        selectedPower = selectedPower ? (selectedPower.charAt(0).toUpperCase() + selectedPower.slice(1)).replaceAll("_"," ") : "null";
-        mpHover = `&cMagical Power: &e${fn(mp)}\n&cSelected Power: &e${selectedPower}\n&cTuning points: `;
-        let temp = false;
-        if (tunings) {
-            for (let statname in tunings) {
-                if (tunings[statname] != 0) {
-                    if (temp) mpHover += ", ";
-                    mpHover += "&f" + String(tunings[statname]) + " &7" + (statname.charAt(0).toUpperCase() + statname.slice(1)).replaceAll("_"," ")
-                    temp = true
-                }
-            }
+    if (!abStorage) return { mp, mpHover }
+
+    mp = abStorage.highest_magical_power || null
+    let selectedPower = abStorage.selected_power || null
+    let tunings = abStorage.tuning?.slot_0 || null
+
+    selectedPower = selectedPower ? (selectedPower.charAt(0).toUpperCase() + selectedPower.slice(1)).replace(/_/g," ") : "NONE"
+    mpHover = `&cMagical Power: &e${fn(mp)}\n&cSelected Power: &e${selectedPower}\n&cTuning points: `
+    let temp = false
+    if (tunings) {
+        for (let statname in tunings) {
+            if (tunings[statname] == 0) continue
+
+            if (temp) mpHover += ", "
+            mpHover += "&f" + String(tunings[statname]) + " &7" + (statname.charAt(0).toUpperCase() + statname.slice(1)).replaceAll("_"," ")
+            temp = true
         }
     }
 
@@ -30,69 +31,80 @@ export function getMpInfo(sbProfile) {
 const spiritSymbol = "⩀"
 export function getSpiritPetStatus(sbProfile) {
     if (sbProfile.pets_data?.pets?.some(a => a.type == "SPIRIT" && a.tier == "LEGENDARY")) {
-		return {spirit: true,spiritText: "&a" + spiritSymbol}
-	} else {
-        return {spirit: false,spiritText: "&c" + spiritSymbol + " &0&lNO SPIRIT"}
-    }
+		return { spirit: true,spiritText: "&a" + spiritSymbol }
+	}
+
+    return { spirit: false,spiritText: "&c" + spiritSymbol + " &0&lNO SPIRIT" }
 }
 
 const gdragSymbol = "GDRAG"
 export function getGdragStatus(sbProfile) {
     const gdrags = sbProfile.pets_data?.pets?.filter(a => a.type == "GOLDEN_DRAGON")
     if (!gdrags || !gdrags.length) return {gdragText: "&c" + gdragSymbol,gdragHover: "&eNo Golden Dragon Pet"}
-    let missingBalance = false;
-    const bank = sbProfile.banking;
-    if (bank && bank.balance < 990_000_000) missingBalance = true;
+    let missingBalance = false
+    const bank = sbProfile.banking
+    if (bank && bank.balance < 990_000_000) missingBalance = true
 
 
-    let hasLevel200 = false;
-    let shelmetGdrag = false;
-    let remediesGdrag = false;
-    let relicGdrag = false;
+    let hasLevel200 = false
+    let shelmetGdrag = false
+    let remediesGdrag = false
+    let relicGdrag = false
     for(let g of gdrags) {
-        if (g.exp > 210_255_385) hasLevel200 = true;
-        if (g.heldItem === "DWARF_TURTLE_SHELMET") shelmetGdrag = true;
-        if (g.heldItem === "ANTIQUE_REMEDIES") remediesGdrag = true;
-        if (g.heldItem === "MINOS_RELIC") relicGdrag = true;
+        if (g.exp > 210_255_385) hasLevel200 = true
+        if (g.heldItem === "DWARF_TURTLE_SHELMET") shelmetGdrag = true
+        if (g.heldItem === "ANTIQUE_REMEDIES") remediesGdrag = true
+        if (g.heldItem === "MINOS_RELIC") relicGdrag = true
     }
 
     if (missingBalance) {
-        return {gdragText: "&4" + (gdrags.length > 1 ? (gdrags.length+" ") : "") + gdragSymbol,gdragHover: `&e${gdrags.length} Golden Dragon Pets&r\n&cOnly ${fn(Math.floor(bank.balance))} in bank${!hasLevel200 ? "\n\n&cNo Level 200" : ""}`};
+        return {
+            gdragText: "&4" + (gdrags.length > 1 ? (gdrags.length+" ") : "") + gdragSymbol,
+            gdragHover: `&e${gdrags.length} Golden Dragon Pets&r` + 
+                `&cOnly ${fn(Math.floor(bank.balance))} in bank${!hasLevel200 ? "\n\n&cNo Level 200" : ""}`
+            }
     }
 
-    return {gdragText: (hasLevel200 ? "&a" : "&4") + (gdrags.length > 1 ? (gdrags.length+" ") : "") + gdragSymbol,gdragHover: `&e${gdrags.length} Golden Dragon Pets&r\n${shelmetGdrag ? "&a" : "&c"}Dwarf Turtle Shelmet\n${remediesGdrag ? "&a" : "&c"}Antique Remedies\n${relicGdrag ? "&a" : "&c"}Minos Relic${!hasLevel200 ? "\n\n&cNo Level 200" : ""}`};
+    return {
+        gdragText: (hasLevel200 ? "&a" : "&4") + (gdrags.length > 1 ? (gdrags.length+" ") : "") + gdragSymbol,
+        gdragHover: `&e${gdrags.length} Golden Dragon Pets&r\n` + 
+            `${shelmetGdrag ? "&a" : "&c"}Dwarf Turtle Shelmet\n` + 
+            `${remediesGdrag ? "&a" : "&c"}Antique Remedies\n` + 
+            `${relicGdrag ? "&a" : "&c"}Minos Relic${!hasLevel200 ? "\n\n&cNo Level 200" : ""}`
+    }
 }
 
 const arrowSymbol = "↣"
 export function getSelectedArrows(sbProfile) {
-    let arrow = sbProfile.item_data?.favorite_arrow;
-    if (!arrow) return "&c" + arrowSymbol + " No Arrow Selected";
+    let arrow = sbProfile.item_data?.favorite_arrow
+    const arrowMatch = arrow?.match(/^(.+?)_ARROW$/)
 
-    arrow = arrow.replace("ARROW","").replaceAll("_"," ").toLowerCase().split(" ").map(a => a.charAt(0).toUpperCase() + a.slice(1)).join(" ");
-    if (arrow === "Armorshred") arrow = "Shred"
-    return "&c" + arrowSymbol + " &e" + arrow;
+    if (!arrowMatch) return "&c" + arrowSymbol + " No Arrow Selected"
+    const [_, arrowType] = arrowMatch
+
+    return "&c" + arrowSymbol + " &e" + title(arrowType.replace(/_/g, " "))
 }
 
 export function getSbLevelInfo(sbProfile) {
-    let level = sbProfile.leveling?.experience;
-    if (!level) level = 0;
-    level = Math.floor(level/100);
+    let level = sbProfile.leveling?.experience
+    if (!level) level = 0
+    level = Math.floor(level/100)
     level = `&f&l[${getLevelColor(level)}${level}&r&f]`
-    return level;
+    return level
 }
 
 
 function getLevelColor(level) {
-	if (level < 80) return "&f";
-	if (level < 160) return "&a";
-	if (level < 200) return "&2";
-	if (level < 240) return "&b";
-	if (level < 280) return "&3";
-	if (level < 320) return "&9";
-	if (level < 360) return "&d";
-	if (level < 400) return "&5";
-	if (level < 440) return "&6";
-	if (level < 120) return "&e";
-	if (level < 480) return "&c";
-	return "&4";
+	if (level < 80) return "&f"
+	if (level < 160) return "&a"
+	if (level < 200) return "&2"
+	if (level < 240) return "&b"
+	if (level < 280) return "&3"
+	if (level < 320) return "&9"
+	if (level < 360) return "&d"
+	if (level < 400) return "&5"
+	if (level < 440) return "&6"
+	if (level < 120) return "&e"
+	if (level < 480) return "&c"
+	return "&4"
 }


### PR DESCRIPTION
Add an advanced mode for `/ds` and `//kuudra`, as well as always show Magical Power (MP) in the result of the /ds command; to do so, I had to move the S and S+ Pbs to the "Completions" directly in a table (the indentations can be sometimes imperfect, but fine on most profiles from my testing):
![image](https://github.com/user-attachments/assets/40a06d44-1d6b-4409-b332-5cef5d87ebdf)

More advanced features are:
- MP (hover will show selected power and tunings)
- Sb level
- Spirit pet status
- Gdrags status: how many, with what pet items, is bank at 1b
- Selected arrow type

See attached example screenshots:
- `/ds` in non advanced mode
![image](https://github.com/user-attachments/assets/d462beb7-80d1-4a41-a648-16e925503e2c)
- `/ds` in advanced mode 
![image](https://github.com/user-attachments/assets/4478a6b4-0ef0-420b-aa5f-d6b3194ecd62)
![image](https://github.com/user-attachments/assets/54259682-d8c7-419d-916d-d044770c2052)
- `//kuudra` in non advanced mode: 
![image](https://github.com/user-attachments/assets/615e1bd9-7c9e-414f-860f-8b860ff0dbba)
- `//kuudra` in advanced mode: 
![image](https://github.com/user-attachments/assets/b613df7d-bc32-4395-a5fc-c843ec832294)
![image](https://github.com/user-attachments/assets/d04c0984-e3ed-4acc-9514-66fe1698e2b9)

Other additions:
- Activating auto ds for dungeons will also activate it for kuudra pf
- Changed kuudra command to use the modern api/api helpers

Possible improvements:
- Add highest wave beaten for kuudra
- Add lifeline level for kuudra